### PR TITLE
Create new data & auth UI

### DIFF
--- a/App/Acquaint.Native/Acquaint.Native.Droid/Acquaint.Native.Droid.csproj
+++ b/App/Acquaint.Native/Acquaint.Native.Droid/Acquaint.Native.Droid.csproj
@@ -12,7 +12,6 @@
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AndroidApplication>True</AndroidApplication>
-    <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
     <AssemblyName>Acquaint.Native.Droid</AssemblyName>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v7.1</TargetFrameworkVersion>

--- a/App/Acquaint.Native/Acquaint.Native.Droid/Properties/AndroidManifest.xml
+++ b/App/Acquaint.Native/Acquaint.Native.Droid/Properties/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.xamarin.acquaintnative" android:versionCode="151" android:versionName="1.51">
 	<uses-sdk android:minSdkVersion="17" />
 	<uses-permission android:name="android.permission.INTERNET" />

--- a/App/Acquaint.XForms/Acquaint.XForms.Droid/Properties/AndroidManifest.xml
+++ b/App/Acquaint.XForms/Acquaint.XForms.Droid/Properties/AndroidManifest.xml
@@ -10,18 +10,14 @@
 	<uses-permission android:name="android.permission.READ_PHONE_STATE" />
 	<uses-permission android:name="android.permission.READ_LOGS" />
 	<application android:label="Acquaint XF" android:theme="@style/AcquaintTheme">
-    <activity android:name="com.microsoft.identity.client.BrowserTabActivity">
-      <intent-filter>
-        <action android:name="android.intent.action.VIEW" />
-
-        <category android:name="android.intent.category.DEFAULT" />
-        <category android:name="android.intent.category.BROWSABLE" />
-
-        <data
-            android:host="auth"
-            android:scheme="msale2a89d4b-929c-4936-9b70-e33ace1ac02c" />
-      </intent-filter>
-    </activity>
+		<activity android:name="com.microsoft.identity.client.BrowserTabActivity">
+			<intent-filter>
+				<action android:name="android.intent.action.VIEW" />
+				<category android:name="android.intent.category.DEFAULT" />
+				<category android:name="android.intent.category.BROWSABLE" />
+				<data android:host="auth" android:scheme="msale2a89d4b-929c-4936-9b70-e33ace1ac02c" />
+			</intent-filter>
+		</activity>
 		<!-- Put your Google Maps V2 API Key here. -->
 		<meta-data android:name="com.google.android.maps.v2.API_KEY" android:value="AIzaSyB9kZU_zfTpbAV9MPb1GSCJeF93yAElvw4" />
 		<meta-data android:name="com.google.android.gms.version" android:value="@integer/google_play_services_version" />

--- a/App/Acquaint.XForms/Acquaint.XForms/Acquaint.XForms.csproj
+++ b/App/Acquaint.XForms/Acquaint.XForms/Acquaint.XForms.csproj
@@ -63,6 +63,8 @@
     <Compile Include="Pages\SetupPage.cs">
       <DependentUpon>SetupPage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="IPageModel.cs" />
+    <Compile Include="ViewModels\DataDocumentTemplateSelector.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <ItemGroup>

--- a/App/Acquaint.XForms/Acquaint.XForms/IPageModel.cs
+++ b/App/Acquaint.XForms/Acquaint.XForms/IPageModel.cs
@@ -1,0 +1,8 @@
+﻿using System;
+namespace Acquaint.XForms
+{
+    public interface IPageModel
+    {
+
+    }
+}

--- a/App/Acquaint.XForms/Acquaint.XForms/Pages/AcquaintanceDetailPage.xaml
+++ b/App/Acquaint.XForms/Acquaint.XForms/Pages/AcquaintanceDetailPage.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="Acquaint.XForms.AcquaintanceDetailPage" Title="{Binding Acquaintance.DisplayName}" xmlns:local="clr-namespace:Acquaint.XForms" xmlns:ffimageloading="clr-namespace:FFImageLoading.Forms;assembly=FFImageLoading.Forms" xmlns:fftransformations="clr-namespace:FFImageLoading.Transformations;assembly=FFImageLoading.Transformations" xmlns:maps="clr-namespace:Xamarin.Forms.Maps;assembly=Xamarin.Forms.Maps" NavigationPage.BackButtonTitle="Details">
 	<ContentPage.Resources>
 		<ResourceDictionary>
@@ -6,7 +6,6 @@
 		</ResourceDictionary>
 	</ContentPage.Resources>
 	<ContentPage.ToolbarItems>
-		<ToolbarItem Text="Delete" Icon="delete.png" Command="{Binding DeleteAcquaintanceCommand}" />
 		<ToolbarItem Text="Edit" Icon="edit.png" Command="{Binding EditAcquaintanceCommand}" />
 	</ContentPage.ToolbarItems>
 	<ContentPage.Content>

--- a/App/Acquaint.XForms/Acquaint.XForms/Pages/AcquaintanceListPage.xaml
+++ b/App/Acquaint.XForms/Acquaint.XForms/Pages/AcquaintanceListPage.xaml
@@ -1,134 +1,150 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="Acquaint.XForms.AcquaintanceListPage" xmlns:local="clr-namespace:Acquaint.XForms" xmlns:ffimageloading="clr-namespace:FFImageLoading.Forms;assembly=FFImageLoading.Forms" xmlns:fftransformations="clr-namespace:FFImageLoading.Transformations;assembly=FFImageLoading.Transformations" x:Name="acquaintanceListPage" NavigationPage.BackButtonTitle="List">
-	<ContentPage.Resources>
-		<ResourceDictionary>
-			<local:BooleanInverter x:Key="BooleanInverter" />
-		</ResourceDictionary>
-	</ContentPage.Resources>
-	<ContentPage.ToolbarItems>
-    <!-- The Refresh ToolBarItem is only for UWP. See code-behind. -->
-    <ToolbarItem x:Name="refreshToolbarItem" Icon="refresh.png" Text="Refresh" Command="{Binding RefreshAcquaintancesCommand}" />
-    <!-- The Settings ToolBarItem is present on all platforms. -->
-        <ToolbarItem x:Name="settingsToolbarItem" Icon="settings.png" Text="Settings" Command="{Binding ShowSettingsCommand}" />
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <local:BooleanInverter x:Key="BooleanInverter" />
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    <ContentPage.ToolbarItems>
+        <!-- The Refresh ToolBarItem is only for UWP. See code-behind. -->
+        <ToolbarItem x:Name="refreshToolbarItem" Icon="refresh.png" Text="Refresh" Command="{Binding RefreshAcquaintancesCommand}" />
+        <!-- The Settings ToolBarItem is present on all platforms. -->
         <ToolbarItem x:Name="signInToolbarItem" Text="{Binding SignInOut.SignedInState}" Command="{Binding ShowSignIn}" />
-    <!-- The Add Acquaintance ToolBarItem is removed for Android. See code-behind.  -->
-		<ToolbarItem x:Name="addAcquaintanceToolbarItem" Icon="add.png" Text="New" Command="{Binding NewAcquaintanceCommand}" />
-	</ContentPage.ToolbarItems>
-	<ContentPage.Content>
-		<OnPlatform x:TypeArguments="View">
-			
-			<!-- Here we have three different listview layouts, one for each platform. Mainly to support the floating action button in our Android version of the app. -->
-			<!-- You could simply have a single layout for all platforms, but our particular app design dictates some slight differences between platforms. -->
-			
-			<OnPlatform.iOS>
-				<!-- Using RetailElement as the CachingStrategy only on iOS and only until this fix is released: https://github.com/xamarin/Xamarin.Forms/pull/338 -->
-				<ListView ItemsSource="{Binding Acquaintances}" CachingStrategy="RetainElement" RowHeight="60" HasUnevenRows="false" ItemTapped="ItemTapped" IsPullToRefreshEnabled="true" RefreshCommand="{Binding RefreshAcquaintancesCommand}" IsRefreshing="{Binding IsBusy, Mode=OneWay}">
-					<ListView.ItemTemplate>
-						<DataTemplate>
-							<ViewCell StyleId="disclosure" Height="60">
-								<!-- Commenting out the ViewCell.ContextActions until this fix is released: https://github.com/xamarin/Xamarin.Forms/pull/338 -->
-								<!--<ViewCell.ContextActions>
-									<MenuItem Text="Email" Command="{Binding Source={x:Reference acquaintanceListPage}, Path=BindingContext.EmailCommand}" CommandParameter="{Binding Id}" />
-									<MenuItem Text="Text" Command="{Binding Source={x:Reference acquaintanceListPage}, Path=BindingContext.MessageNumberCommand}" CommandParameter="{Binding Id}" />
-									<MenuItem Text="Call" Command="{Binding Source={x:Reference acquaintanceListPage}, Path=BindingContext.DialNumberCommand}" CommandParameter="{Binding Id}" />
-								</ViewCell.ContextActions>-->
-								<AbsoluteLayout>
-									<StackLayout Orientation="Horizontal" Spacing="0" AbsoluteLayout.LayoutFlags="XProportional" AbsoluteLayout.LayoutBounds="0,0,AutoSize,AutoSize">
-										<ContentView Margin="3" WidthRequest="54">
-											<ffimageloading:CachedImage HorizontalOptions="Center" VerticalOptions="Center" WidthRequest="50" HeightRequest="50" DownsampleToViewSize="true" Source="{Binding SmallPhotoUrl}" LoadingPlaceholder="placeholderProfileImage.png">
-												<ffimageloading:CachedImage.Transformations>
-													<fftransformations:CircleTransformation />
-												</ffimageloading:CachedImage.Transformations>
-											</ffimageloading:CachedImage>
-										</ContentView>
-										<ContentView Padding="10,0,0,0">
-											<StackLayout Spacing="0">
-												<Label Text="{Binding DisplayLastNameFirst}" HeightRequest="20" VerticalTextAlignment="End" LineBreakMode="TailTruncation" />
-												<Label Text="{Binding Company}" HeightRequest="20" VerticalTextAlignment="End" FontSize="Micro" LineBreakMode="TailTruncation" />
-												<Label Text="{Binding JobTitle}" HeightRequest="20" VerticalTextAlignment="Start" FontSize="Micro" LineBreakMode="TailTruncation" TextColor="Silver" />
-											</StackLayout>
-										</ContentView>
-									</StackLayout>
-								</AbsoluteLayout>
-							</ViewCell>
-						</DataTemplate>
-					</ListView.ItemTemplate>
-				</ListView>
-			</OnPlatform.iOS>
-			
-			<OnPlatform.Android>
-				<AbsoluteLayout>
-					<AbsoluteLayout.Children>
-						<ListView ItemsSource="{Binding Acquaintances}" CachingStrategy="RecycleElement" RowHeight="60" HasUnevenRows="false" ItemTapped="ItemTapped" IsPullToRefreshEnabled="true" RefreshCommand="{Binding RefreshAcquaintancesCommand}" IsRefreshing="{Binding IsBusy, Mode=OneWay}" AbsoluteLayout.LayoutFlags="All" AbsoluteLayout.LayoutBounds="0,0,1,1">
-							<ListView.ItemTemplate>
-								<DataTemplate>
-									<ViewCell StyleId="disclosure" Height="60">
-										<ViewCell.ContextActions>
-											<MenuItem Text="Email" Command="{Binding Source={x:Reference acquaintanceListPage}, Path=BindingContext.EmailCommand}" CommandParameter="{Binding Id}" />
-											<MenuItem Text="Text" Command="{Binding Source={x:Reference acquaintanceListPage}, Path=BindingContext.MessageNumberCommand}" CommandParameter="{Binding Id}" />
-											<MenuItem Text="Call" Command="{Binding Source={x:Reference acquaintanceListPage}, Path=BindingContext.DialNumberCommand}" CommandParameter="{Binding Id}" />
-										</ViewCell.ContextActions>
-										<ContentView Padding="10,0">
-											<StackLayout Orientation="Horizontal" Spacing="0">
-												<ContentView Margin="3" WidthRequest="54">
-													<ffimageloading:CachedImage HorizontalOptions="Center" VerticalOptions="Center" WidthRequest="50" HeightRequest="50" DownsampleToViewSize="true" Source="{Binding SmallPhotoUrl}" LoadingPlaceholder="placeholderProfileImage.png">
-														<ffimageloading:CachedImage.Transformations>
-															<fftransformations:CircleTransformation />
-														</ffimageloading:CachedImage.Transformations>
-													</ffimageloading:CachedImage>
-												</ContentView>
-												<ContentView Padding="10,0,0,0">
-													<StackLayout Spacing="0">
-														<Label Text="{Binding DisplayLastNameFirst}" HeightRequest="20" VerticalTextAlignment="End" LineBreakMode="TailTruncation" />
-														<Label Text="{Binding Company}" HeightRequest="20" VerticalTextAlignment="End" FontSize="Micro" LineBreakMode="TailTruncation" />
-														<Label Text="{Binding JobTitle}" HeightRequest="20" VerticalTextAlignment="Start" FontSize="Micro" LineBreakMode="TailTruncation" TextColor="Silver" />
-													</StackLayout>
-												</ContentView>
-											</StackLayout>
-										</ContentView>
-									</ViewCell>
-								</DataTemplate>
-							</ListView.ItemTemplate>
-						</ListView>
-						<local:FloatingActionButtonView x:Name="fab" ImageName="fab_add" ColorNormal="#547799" ColorPressed="#172839" ColorRipple="#2C3E50" AbsoluteLayout.LayoutBounds="1.0, 1.0, AutoSize, AutoSize" AbsoluteLayout.LayoutFlags="PositionProportional" />
-					</AbsoluteLayout.Children>
-				</AbsoluteLayout>
-			</OnPlatform.Android>
-			
-			<OnPlatform.WinPhone>
-				<ListView ItemsSource="{Binding Acquaintances}" CachingStrategy="RecycleElement" RowHeight="60" HasUnevenRows="false" ItemTapped="ItemTapped" IsPullToRefreshEnabled="true" RefreshCommand="{Binding RefreshAcquaintancesCommand}" IsRefreshing="{Binding IsBusy, Mode=OneWay}" AbsoluteLayout.LayoutFlags="All" AbsoluteLayout.LayoutBounds="0,0,1,1">
-					<ListView.ItemTemplate>
-						<DataTemplate>
-							<ViewCell StyleId="disclosure" Height="60">
-								<ViewCell.ContextActions>
-									<MenuItem Text="Email" Command="{Binding Source={x:Reference acquaintanceListPage}, Path=BindingContext.EmailCommand}" CommandParameter="{Binding Id}" />
-									<MenuItem Text="Text" Command="{Binding Source={x:Reference acquaintanceListPage}, Path=BindingContext.MessageNumberCommand}" CommandParameter="{Binding Id}" />
-									<MenuItem Text="Call" Command="{Binding Source={x:Reference acquaintanceListPage}, Path=BindingContext.DialNumberCommand}" CommandParameter="{Binding Id}" />
-								</ViewCell.ContextActions>
-								<ContentView Padding="10,0">
-									<StackLayout Orientation="Horizontal" Spacing="0">
-										<ContentView Margin="3" WidthRequest="54">
-											<ffimageloading:CachedImage HorizontalOptions="Center" VerticalOptions="Center" WidthRequest="50" HeightRequest="50" DownsampleToViewSize="true" Source="{Binding SmallPhotoUrl}" LoadingPlaceholder="placeholderProfileImage.png">
-												<ffimageloading:CachedImage.Transformations>
-													<fftransformations:CircleTransformation />
-												</ffimageloading:CachedImage.Transformations>
-											</ffimageloading:CachedImage>
-										</ContentView>
-										<ContentView Padding="10,0,0,0">
-											<StackLayout Spacing="0">
-												<Label Text="{Binding DisplayLastNameFirst}" HeightRequest="20" VerticalTextAlignment="End" LineBreakMode="TailTruncation" />
-												<Label Text="{Binding Company}" HeightRequest="20" VerticalTextAlignment="End" FontSize="Micro" LineBreakMode="TailTruncation" />
-												<Label Text="{Binding JobTitle}" HeightRequest="20" VerticalTextAlignment="Start" FontSize="Micro" LineBreakMode="TailTruncation" TextColor="Silver" />
-											</StackLayout>
-										</ContentView>
-									</StackLayout>
-								</ContentView>
-							</ViewCell>
-						</DataTemplate>
-					</ListView.ItemTemplate>
-				</ListView>
-			</OnPlatform.WinPhone>
-			
-		</OnPlatform>
-	</ContentPage.Content>
+        <!-- The Add Acquaintance ToolBarItem is removed for Android. See code-behind.  -->
+        <ToolbarItem x:Name="addAcquaintanceToolbarItem" Icon="add.png" Text="New" Command="{Binding NewAcquaintanceCommand}" />
+    </ContentPage.ToolbarItems>
+    <ContentPage.Content>
+        <OnPlatform x:TypeArguments="View">
+            <!-- Here we have three different listview layouts, one for each platform. Mainly to support the floating action button in our Android version of the app. -->
+            <!-- You could simply have a single layout for all platforms, but our particular app design dictates some slight differences between platforms. -->
+            <OnPlatform.iOS>
+                <!-- Using RetailElement as the CachingStrategy only on iOS and only until this fix is released: https://github.com/xamarin/Xamarin.Forms/pull/338 -->
+                <ListView ItemsSource="{Binding Acquaintances}" CachingStrategy="RetainElement" RowHeight="60" HasUnevenRows="false" ItemTapped="ItemTapped" IsPullToRefreshEnabled="true" RefreshCommand="{Binding RefreshAcquaintancesCommand}" IsRefreshing="{Binding IsBusy, Mode=OneWay}">
+                    <ListView.ItemTemplate>
+                        <DataTemplate>
+                            <ViewCell StyleId="disclosure" Height="60">
+                                <!-- Commenting out the ViewCell.ContextActions until this fix is released: https://github.com/xamarin/Xamarin.Forms/pull/338 -->
+                                <!--<ViewCell.ContextActions>
+                                    <MenuItem Text="Email" Command="{Binding Source={x:Reference acquaintanceListPage}, Path=BindingContext.EmailCommand}" CommandParameter="{Binding Id}" />
+                                    <MenuItem Text="Text" Command="{Binding Source={x:Reference acquaintanceListPage}, Path=BindingContext.MessageNumberCommand}" CommandParameter="{Binding Id}" />
+                                    <MenuItem Text="Call" Command="{Binding Source={x:Reference acquaintanceListPage}, Path=BindingContext.DialNumberCommand}" CommandParameter="{Binding Id}" />
+                                </ViewCell.ContextActions>-->
+                                <AbsoluteLayout>
+                                    <StackLayout Orientation="Horizontal" Spacing="0" AbsoluteLayout.LayoutFlags="XProportional" AbsoluteLayout.LayoutBounds="0,0,AutoSize,AutoSize">
+                                        <ContentView Margin="3" WidthRequest="54">
+                                            <ffimageloading:CachedImage HorizontalOptions="Center" VerticalOptions="Center" WidthRequest="50" HeightRequest="50" DownsampleToViewSize="true" Source="{Binding SmallPhotoUrl}" LoadingPlaceholder="placeholderProfileImage.png">
+                                                <ffimageloading:CachedImage.Transformations>
+                                                    <fftransformations:CircleTransformation />
+                                                </ffimageloading:CachedImage.Transformations>
+                                            </ffimageloading:CachedImage>
+                                        </ContentView>
+                                        <ContentView Padding="10,0,0,0">
+                                            <StackLayout Spacing="0">
+                                                <Label Text="{Binding DisplayLastNameFirst}" HeightRequest="20" VerticalTextAlignment="End" LineBreakMode="TailTruncation" />
+                                                <Label Text="{Binding Company}" HeightRequest="20" VerticalTextAlignment="End" FontSize="Micro" LineBreakMode="TailTruncation" />
+                                                <Label Text="{Binding JobTitle}" HeightRequest="20" VerticalTextAlignment="Start" FontSize="Micro" LineBreakMode="TailTruncation" TextColor="Silver" />
+                                            </StackLayout>
+                                        </ContentView>
+                                    </StackLayout>
+                                </AbsoluteLayout>
+                            </ViewCell>
+                        </DataTemplate>
+                    </ListView.ItemTemplate>
+                </ListView>
+            </OnPlatform.iOS>
+            <OnPlatform.Android>
+                <AbsoluteLayout>
+                    <AbsoluteLayout.Children>
+                        <ListView ItemsSource="{Binding _AcquaintancesTest}" CachingStrategy="RecycleElement" RowHeight="60" HasUnevenRows="false" ItemTapped="ItemTapped" IsPullToRefreshEnabled="true" RefreshCommand="{Binding RefreshAcquaintancesCommand}" IsRefreshing="{Binding IsBusy, Mode=OneWay}" AbsoluteLayout.LayoutFlags="All" AbsoluteLayout.LayoutBounds="0,0,1,1">
+                            <ListView.ItemTemplate>
+                                <DataTemplate x:Key="UserData">
+                                    <ViewCell StyleId="disclosure" Height="60">
+                                        <ViewCell.ContextActions>
+                                            <MenuItem Text="Email" Command="{Binding Source={x:Reference acquaintanceListPage}, Path=BindingContext.EmailCommand}" CommandParameter="{Binding Id}" />
+                                            <MenuItem Text="Text" Command="{Binding Source={x:Reference acquaintanceListPage}, Path=BindingContext.MessageNumberCommand}" CommandParameter="{Binding Id}" />
+                                            <MenuItem Text="Call" Command="{Binding Source={x:Reference acquaintanceListPage}, Path=BindingContext.DialNumberCommand}" CommandParameter="{Binding Id}" />
+                                        </ViewCell.ContextActions>
+                                        <ContentView Padding="10,0">
+                                            <StackLayout Orientation="Horizontal" Spacing="0">
+                                                <ContentView Margin="3" WidthRequest="54">
+                                                    <ffimageloading:CachedImage HorizontalOptions="Center" VerticalOptions="Center" WidthRequest="50" HeightRequest="50" DownsampleToViewSize="true" Source="{Binding SmallPhotoUrl}" LoadingPlaceholder="placeholderProfileImage.png">
+                                                        <ffimageloading:CachedImage.Transformations>
+                                                            <fftransformations:CircleTransformation />
+                                                        </ffimageloading:CachedImage.Transformations>
+                                                    </ffimageloading:CachedImage>
+                                                </ContentView>
+                                                <ContentView Padding="10,0,0,0">
+                                                    <RelativeLayout Orientation="Horizontal">
+                                                        <StackLayout Orientation="Vertical" Spacing="0">
+                                                            <Label Text="{Binding DisplayLastNameFirst}" HeightRequest="20" VerticalTextAlignment="End" LineBreakMode="TailTruncation" />
+                                                            <Label Text="{Binding Company}" HeightRequest="20" VerticalTextAlignment="End" FontSize="Micro" LineBreakMode="TailTruncation" />
+                                                            <Label Text="{Binding JobTitle}" HeightRequest="20" VerticalTextAlignment="Start" FontSize="Micro" LineBreakMode="TailTruncation" TextColor="Silver" />
+                                                        </StackLayout>
+                                                        <Button Text="DEL" BackgroundColor="Maroon" Command="{Binding DeleteAcquaintanceCommand}" />
+                                                    </RelativeLayout>
+                                                </ContentView>
+                                            </StackLayout>
+                                        </ContentView>
+                                    </ViewCell>
+                                </DataTemplate>
+                                <DataTemplate x:Key="AppData">
+                                    <ViewCell StyleId="disclosure" Height="60">
+                                        <ContentView Padding="10,0,0,0">
+                                            <RelativeLayout Orientation="Horizontal">
+                                                <StackLayout Orientation="Vertical" Spacing="0">
+                                                    <Label Text="{Binding Title}" HeightRequest="20" VerticalTextAlignment="End" LineBreakMode="TailTruncation" />
+                                                </StackLayout>
+                                            </RelativeLayout>
+                                        </ContentView>
+                                    </ViewCell>
+                                </DataTemplate>
+                                <DataTemplate x:Key="HeaderData">
+                                    <ViewCell StyleId="disclosure" Height="30">
+                                         <Label Text="{Binding Title}" HeightRequest="20" VerticalTextAlignment="End" LineBreakMode="TailTruncation" />
+                                    </ViewCell>
+                                </DataTemplate>
+                            </ListView.ItemTemplate>
+                        </ListView>
+                        <local:DataDocumentTemplateSelector x:Key="dataDocumentTemplateSelector"
+                                                            HeaderTemplate="{StaticResource UserData}"
+                                                            AppTemplate="{StaticResource AppData}"
+                                                            UserTemplate="{StaticResource HeaderData}" />
+                    </AbsoluteLayout.Children>
+                </AbsoluteLayout>
+            </OnPlatform.Android>
+            <OnPlatform.WinPhone>
+                <ListView ItemsSource="{Binding Acquaintances}" CachingStrategy="RecycleElement" RowHeight="60" HasUnevenRows="false" ItemTapped="ItemTapped" IsPullToRefreshEnabled="true" RefreshCommand="{Binding RefreshAcquaintancesCommand}" IsRefreshing="{Binding IsBusy, Mode=OneWay}" AbsoluteLayout.LayoutFlags="All" AbsoluteLayout.LayoutBounds="0,0,1,1">
+                    <ListView.ItemTemplate>
+                        <DataTemplate>
+                            <ViewCell StyleId="disclosure" Height="60">
+                                <ViewCell.ContextActions>
+                                    <MenuItem Text="Email" Command="{Binding Source={x:Reference acquaintanceListPage}, Path=BindingContext.EmailCommand}" CommandParameter="{Binding Id}" />
+                                    <MenuItem Text="Text" Command="{Binding Source={x:Reference acquaintanceListPage}, Path=BindingContext.MessageNumberCommand}" CommandParameter="{Binding Id}" />
+                                    <MenuItem Text="Call" Command="{Binding Source={x:Reference acquaintanceListPage}, Path=BindingContext.DialNumberCommand}" CommandParameter="{Binding Id}" />
+                                </ViewCell.ContextActions>
+                                <ContentView Padding="10,0">
+                                    <StackLayout Orientation="Horizontal" Spacing="0">
+                                        <ContentView Margin="3" WidthRequest="54">
+                                            <ffimageloading:CachedImage HorizontalOptions="Center" VerticalOptions="Center" WidthRequest="50" HeightRequest="50" DownsampleToViewSize="true" Source="{Binding SmallPhotoUrl}" LoadingPlaceholder="placeholderProfileImage.png">
+                                                <ffimageloading:CachedImage.Transformations>
+                                                    <fftransformations:CircleTransformation />
+                                                </ffimageloading:CachedImage.Transformations>
+                                            </ffimageloading:CachedImage>
+                                        </ContentView>
+                                        <ContentView Padding="10,0,0,0">
+                                            <StackLayout Spacing="0">
+                                                <Label Text="{Binding DisplayLastNameFirst}" HeightRequest="20" VerticalTextAlignment="End" LineBreakMode="TailTruncation" />
+                                                <Label Text="{Binding Company}" HeightRequest="20" VerticalTextAlignment="End" FontSize="Micro" LineBreakMode="TailTruncation" />
+                                                <Label Text="{Binding JobTitle}" HeightRequest="20" VerticalTextAlignment="Start" FontSize="Micro" LineBreakMode="TailTruncation" TextColor="Silver" />
+                                            </StackLayout>
+                                        </ContentView>
+                                    </StackLayout>
+                                </ContentView>
+                            </ViewCell>
+                        </DataTemplate>
+                    </ListView.ItemTemplate>
+                </ListView>
+            </OnPlatform.WinPhone>
+        </OnPlatform>
+    </ContentPage.Content>
 </ContentPage>

--- a/App/Acquaint.XForms/Acquaint.XForms/Pages/AcquaintanceListPage.xaml.cs
+++ b/App/Acquaint.XForms/Acquaint.XForms/Pages/AcquaintanceListPage.xaml.cs
@@ -13,13 +13,7 @@ namespace Acquaint.XForms
 		{
 			InitializeComponent();
 
-			// on Android, we use a floating action button, so clear the ToolBarItems collection
-			if (Device.OS == TargetPlatform.Android)
-			{
-			    ToolbarItems.Remove(addAcquaintanceToolbarItem);
-
-				fab.Clicked = AndroidAddButtonClicked;
-			}
+			
 
 		    if (Device.OS != TargetPlatform.Windows)
 		    {

--- a/App/Acquaint.XForms/Acquaint.XForms/ViewModels/AcquaintanceDetailViewModel.cs
+++ b/App/Acquaint.XForms/Acquaint.XForms/ViewModels/AcquaintanceDetailViewModel.cs
@@ -55,28 +55,6 @@ namespace Acquaint.XForms
 			await PushAsync(new AcquaintanceEditPage() { BindingContext = new AcquaintanceEditViewModel(Acquaintance) });
         }
 
-		Command _DeleteAcquaintanceCommand;
-
-		public Command DeleteAcquaintanceCommand => _DeleteAcquaintanceCommand ?? (_DeleteAcquaintanceCommand = new Command(ExecuteDeleteAcquaintanceCommand));
-
-		void ExecuteDeleteAcquaintanceCommand()
-		{
-			MessagingService.Current.SendMessage<MessagingServiceQuestion>(MessageKeys.DisplayQuestion, new MessagingServiceQuestion()
-			{
-				Title = string.Format("Delete {0}?", Acquaintance.DisplayName),
-				Question = null,
-				Positive = "Delete",
-				Negative = "Cancel",
-				OnCompleted = new Action<bool>(async result => {
-					if (!result) return;
-
-					// send a message that we want the given acquaintance to be deleted
-					MessagingService.Current.SendMessage<Acquaintance>(MessageKeys.DeleteAcquaintance, Acquaintance);
-
-					await PopAsync();
-				})
-			});
-		}
 
         Command _DialNumberCommand;
 

--- a/App/Acquaint.XForms/Acquaint.XForms/ViewModels/AcquaintanceListViewModel.cs
+++ b/App/Acquaint.XForms/Acquaint.XForms/ViewModels/AcquaintanceListViewModel.cs
@@ -11,6 +11,9 @@ using Xamarin.Forms;
 using Microsoft.AppCenter.Auth;
 using Microsoft.AppCenter.Crashes;
 using Microsoft.AppCenter.Analytics;
+using System;
+using System.Collections.Generic;
+using Acquaint.XForms;
 
 namespace Acquaint.XForms
 {
@@ -36,6 +39,16 @@ namespace Acquaint.XForms
 
         ObservableRangeCollection<Acquaintance> _Acquaintances;
 
+        ObservableRangeCollection<ListItem> _AcquaintancesTest { get {
+                ObservableRangeCollection<ListItem> list = new ObservableRangeCollection<ListItem>();
+                       list.Add(new ListSeparator("App document"));
+                       list.Add((Acquaint.Models.ListItem) new AppDocument());
+                       list.Add(new ListSeparator("User document"));
+                       list.Add(new Acquaintance() { DataPartitionId = "", FirstName = "Joseph", LastName = "Grimes", Company = "GG Mechanical", JobTitle = "Vice President", Email = "jgrimes@ggmechanical.com", Phone = "414-367-4348", Street = "2030 Judah St", City = "San Francisco", PostalCode = "94144", State = "CA", PhotoUrl = "https://acquaint.blob.core.windows.net/images/josephgrimes.jpg" });
+                       list.Add(new Acquaintance() { DataPartitionId = "", FirstName = "Monica", LastName = "Green", Company = "Calcom Logistics", JobTitle = "Director", Email = "mgreen@calcomlogistics.com", Phone = "925-353-8029", Street = "230 3rd Ave", City = "San Francisco", PostalCode = "94118", State = "CA", PhotoUrl = "https://acquaint.blob.core.windows.net/images/monicagreen.jpg" });
+                return list;
+            } }
+
         Command _LoadAcquaintancesCommand;
 
         Command _RefreshAcquaintancesCommand;
@@ -54,7 +67,7 @@ namespace Acquaint.XForms
 
         public ObservableRangeCollection<Acquaintance> Acquaintances
         {
-            get { return _Acquaintances ?? (_Acquaintances = new ObservableRangeCollection<Acquaintance>()); }
+            get { return _Acquaintances ?? (_Acquaintances = new ObservableRangeCollection<Acquaintance>());}
             set
             {
                 _Acquaintances = value;
@@ -74,7 +87,7 @@ namespace Acquaint.XForms
         {
             LoadAcquaintancesCommand.ChangeCanExecute();
 
-			// set the data source on each load, because we don't know if the data source may have been updated between page loads
+			// set the data source on each load, becaus+e we don't know if the data source may have been updated between page loads
 			SetDataSource();
 
             if (Settings.LocalDataResetIsRequested)
@@ -373,6 +386,39 @@ namespace Acquaint.XForms
                 IsBusy = false;
             });
         }
+
+        Command _DeleteAcquaintanceCommand;
+
+        public Command DeleteAcquaintanceCommand => _DeleteAcquaintanceCommand ?? (_DeleteAcquaintanceCommand = new Command(ExecuteDeleteAcquaintanceCommand));
+
+        void ExecuteDeleteAcquaintanceCommand()
+        {
+            MessagingService.Current.SendMessage<MessagingServiceQuestion>(MessageKeys.DisplayQuestion, new MessagingServiceQuestion()
+            {
+                //Title = string.Format("Delete {0}?", Acquaintance.DisplayName),
+                Question = null,
+                Positive = "Delete",
+                Negative = "Cancel",
+                OnCompleted = new Action<bool>(async result => {
+                    if (!result) return;
+                        SubscribeToDeleteAcquaintanceMessages();
+                    await PopAsync();
+                })
+            });
+        }
+
+        //private ObservableRangeCollection<ListItem> LoadDataList()
+        //{
+        //    ObservableRangeCollection<ListItem> list = new ObservableRangeCollection<ListItem>();
+        //    //List<ListItem> list = new List<ListItem>();
+        //    //list.Add(new ListSeparator("App document"));
+        //    //list.Add((Acquaint.Models.ListItem) new AppDocument());
+        //    //list.Add(new ListSeparator("User document"));
+        //    //list.Add(new Acquaintance() { DataPartitionId = "", FirstName = "Joseph", LastName = "Grimes", Company = "GG Mechanical", JobTitle = "Vice President", Email = "jgrimes@ggmechanical.com", Phone = "414-367-4348", Street = "2030 Judah St", City = "San Francisco", PostalCode = "94144", State = "CA", PhotoUrl = "https://acquaint.blob.core.windows.net/images/josephgrimes.jpg" });
+        //    //list.Add(new Acquaintance() { DataPartitionId = "", FirstName = "Monica", LastName = "Green", Company = "Calcom Logistics", JobTitle = "Director", Email = "mgreen@calcomlogistics.com", Phone = "925-353-8029", Street = "230 3rd Ave", City = "San Francisco", PostalCode = "94118", State = "CA", PhotoUrl = "https://acquaint.blob.core.windows.net/images/monicagreen.jpg" });
+        //    return list;
+
+        //}
     }
 }
 

--- a/App/Acquaint.XForms/Acquaint.XForms/ViewModels/DataDocumentTemplateSelector.cs
+++ b/App/Acquaint.XForms/Acquaint.XForms/ViewModels/DataDocumentTemplateSelector.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using Acquaint.Models;
+using Acquaint.XForms;
+using Xamarin.Forms;
+
+namespace Acquaint.XForms
+{
+    public class DataDocumentTemplateSelector : DataTemplateSelector
+    {
+        public DataTemplate HeaderTemplate { get; set; }
+        public DataTemplate UserTemplate { get; set; }
+        public DataTemplate AppTemplate { get; set; }
+
+        protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
+        {
+            if (item is Acquaintance)
+            {
+                return UserTemplate;
+            }
+            else if (item is ListSeparator)
+            {
+                return HeaderTemplate;
+            }
+            else
+            {
+                return AppTemplate;
+            }
+        }
+    }
+}

--- a/App/Common/Acquaint.Common.Droid/Acquaint.Common.Droid.csproj
+++ b/App/Common/Acquaint.Common.Droid/Acquaint.Common.Droid.csproj
@@ -24,7 +24,6 @@
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
     <AndroidLinkMode>None</AndroidLinkMode>
-    <AndroidSupportedAbis>arm64-v8a;armeabi-v7a;x86</AndroidSupportedAbis>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>

--- a/App/Common/Acquaint.Models/Acquaint.Models.csproj
+++ b/App/Common/Acquaint.Models/Acquaint.Models.csproj
@@ -36,6 +36,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Acquaintance.cs" />
     <Compile Include="ObservableEntityData.cs" />
+    <Compile Include="AppDocument.cs" />
+    <Compile Include="ListItem.cs" />
+    <Compile Include="ListSeparator.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Common\Acquaint.ModelContracts\Acquaint.ModelContracts.csproj">

--- a/App/Common/Acquaint.Models/Acquaintance.cs
+++ b/App/Common/Acquaint.Models/Acquaintance.cs
@@ -3,9 +3,9 @@ using Newtonsoft.Json;
 
 namespace Acquaint.Models
 {
-	public class Acquaintance : ObservableEntityData, IAcquaintance
+    public class Acquaintance : ObservableEntityData, IAcquaintance, ListItem
     {
-		public string DataPartitionId { get; set; }
+        public string DataPartitionId { get; set; }
 
         string _FirstName;
         public string FirstName
@@ -14,9 +14,9 @@ namespace Acquaint.Models
             set
             {
                 SetProperty(ref _FirstName, value);
-				// DisplayName is dependent on FirstName
+                // DisplayName is dependent on FirstName
                 OnPropertyChanged(nameof(DisplayName));
-				// DisplayLastNameFirst is dependent on FirstName
+                // DisplayLastNameFirst is dependent on FirstName
                 OnPropertyChanged(nameof(DisplayLastNameFirst));
             }
         }
@@ -28,9 +28,9 @@ namespace Acquaint.Models
             set
             {
                 SetProperty(ref _LastName, value);
-				// DisplayName is dependent on LastName
+                // DisplayName is dependent on LastName
                 OnPropertyChanged(nameof(DisplayName));
-				// DisplayLastNameFirst is dependent on LastName
+                // DisplayLastNameFirst is dependent on LastName
                 OnPropertyChanged(nameof(DisplayLastNameFirst));
             }
         }
@@ -70,7 +70,7 @@ namespace Acquaint.Models
             set
             {
                 SetProperty(ref _Street, value);
-				// AddressString is dependent on Street
+                // AddressString is dependent on Street
                 OnPropertyChanged(nameof(AddressString));
             }
         }
@@ -82,7 +82,7 @@ namespace Acquaint.Models
             set
             {
                 SetProperty(ref _City, value);
-				// AddressString is dependent on City
+                // AddressString is dependent on City
                 OnPropertyChanged(nameof(AddressString));
             }
         }
@@ -94,9 +94,9 @@ namespace Acquaint.Models
             set
             {
                 SetProperty(ref _PostalCode, value);
-				// AddressString is dependent on PostalCode
+                // AddressString is dependent on PostalCode
                 OnPropertyChanged(nameof(AddressString));
-				// StatePostal is dependent on PostalCode
+                // StatePostal is dependent on PostalCode
                 OnPropertyChanged(nameof(StatePostal));
             }
         }
@@ -109,9 +109,9 @@ namespace Acquaint.Models
             set
             {
                 SetProperty(ref _State, value);
-				// AddressString is dependent on State
+                // AddressString is dependent on State
                 OnPropertyChanged(nameof(AddressString));
-				// StatePostal is dependent on State
+                // StatePostal is dependent on State
                 OnPropertyChanged(nameof(StatePostal));
             }
         }
@@ -123,7 +123,7 @@ namespace Acquaint.Models
             set
             {
                 SetProperty(ref _PhotoUrl, value);
-				// SmallPhotoUrl is dependent on PhotoUrl
+                // SmallPhotoUrl is dependent on PhotoUrl
                 OnPropertyChanged(nameof(SmallPhotoUrl));
             }
         }
@@ -147,7 +147,7 @@ namespace Acquaint.Models
         [JsonIgnore]
         public string StatePostal => State + " " + PostalCode;
 
-		public override string ToString() => $"{FirstName} {LastName}";
+        public override string ToString() => $"{FirstName} {LastName}";
     }
 }
 

--- a/App/Common/Acquaint.Models/AppDocument.cs
+++ b/App/Common/Acquaint.Models/AppDocument.cs
@@ -1,0 +1,13 @@
+﻿using System;
+namespace Acquaint.Models
+{
+    public class AppDocument : ListItem
+    {
+        public AppDocument()
+        {
+        }
+
+        public string Title { get; set; }
+        public string Description { get; set; }
+    }
+}

--- a/App/Common/Acquaint.Models/ListItem.cs
+++ b/App/Common/Acquaint.Models/ListItem.cs
@@ -1,0 +1,7 @@
+﻿using System;
+namespace Acquaint.Models
+{
+    public interface ListItem
+    {
+    }
+}

--- a/App/Common/Acquaint.Models/ListSeparator.cs
+++ b/App/Common/Acquaint.Models/ListSeparator.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using Acquaint.Models;
+
+namespace Acquaint.XForms
+{
+    public class ListSeparator : ListItem
+    {
+        public ListSeparator(string title)
+        {
+            this.Title = title;
+        }
+
+        public string Title { get; set; }
+    }
+}


### PR DESCRIPTION
Description
Remove the settings page and "add" buttons from the current UI.  Add a login button to the top bar.

The main page for the acquaint app will be divided into 2 sections: public documents and user documents.  The user documents sections should indicate when the user is not logged in.  Adding and removing user documents should work similarly to the Sasquatch applications, with a + button for adding documents and a - button for removing them.  

Issue
AB#60734
